### PR TITLE
Retain all messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ it returns nil
 type Error struct {
 	// Err is the original error (you might call it the root cause)
 	Err error
-	// Message is an annotated description of the error
-	Message string
+	// Messages is an annotated description of the error
+	Messages []string
 	// StatusCode is a status code that is desired to be used for a HTTP response
 	StatusCode int
 	// Ignorable represents whether the error should be reported to administrators
@@ -191,7 +191,7 @@ func main() {
 $ go run main.go
 &fail.Error{
   Err:        &errors.errorString{s: "this is the root cause"},
-  Message:    "fucked up!",
+  Messages:   []string{"fucked up!"},
   StatusCode: 500,
   Ignorable:  true,
   StackTrace: fail.StackTrace{
@@ -244,8 +244,8 @@ func ReportError(c *gin.Context, err error) {
 	}
 
 	// Expose an error message in the header
-	if appErr.Message != "" {
-		c.Header("X-App-Error", appErr.Message)
+	if msg := appErr.LastMessage(); msg != "" {
+		c.Header("X-App-Error", msg)
 	}
 
 	// Set status code accordingly

--- a/error.go
+++ b/error.go
@@ -111,16 +111,12 @@ func wrap(err error) *Error {
 		stackTrace = newStackTrace(1)
 	}
 
-	var messages []string
-	if pkgErr.Message != "" {
-		messages = append(messages, pkgErr.Message)
-	}
-
-	return &Error{
+	wrappedErr := &Error{
 		Err:        pkgErr.Err,
 		StackTrace: stackTrace,
-		Messages:   messages,
 	}
+	WithMessage(pkgErr.Message)(wrappedErr)
+	return wrappedErr
 }
 
 // Unwrap extracts an underlying *fail.Error from an error.

--- a/error.go
+++ b/error.go
@@ -71,11 +71,10 @@ func (e *Error) Copy() *Error {
 
 // LastMessage returns the last message
 func (e *Error) LastMessage() string {
-	l := len(e.Messages)
-	if l == 0 {
+	if len(e.Messages) == 0 {
 		return ""
 	}
-	return e.Messages[l-1]
+	return e.Messages[0]
 }
 
 // FullMessage returns a string of messages concatenated with ": "

--- a/error.go
+++ b/error.go
@@ -111,10 +111,15 @@ func wrap(err error) *Error {
 		stackTrace = newStackTrace(1)
 	}
 
+	var messages []string
+	if pkgErr.Message != "" {
+		messages = append(messages, pkgErr.Message)
+	}
+
 	return &Error{
 		Err:        pkgErr.Err,
 		StackTrace: stackTrace,
-		Messages:   []string{pkgErr.Message},
+		Messages:   messages,
 	}
 }
 

--- a/error.go
+++ b/error.go
@@ -50,7 +50,7 @@ func Errorf(format string, args ...interface{}) error {
 
 // Error implements error interface
 func (e *Error) Error() string {
-	if message := e.AllMessage(); message != "" {
+	if message := e.FullMessage(); message != "" {
 		return message
 	}
 	return e.Err.Error()
@@ -78,8 +78,8 @@ func (e *Error) LastMessage() string {
 	return e.Messages[l-1]
 }
 
-// AllMessage returns a string of messages concatenated with ": "
-func (e *Error) AllMessage() string {
+// FullMessage returns a string of messages concatenated with ": "
+func (e *Error) FullMessage() string {
 	return strings.Join(e.Messages, messageDelimiter)
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -14,7 +14,7 @@ func TestNew(t *testing.T) {
 
 	appErr := Unwrap(err)
 	assert.Equal(t, err.Error(), appErr.Err.Error())
-	assert.Equal(t, "", appErr.Message)
+	assert.Equal(t, "", appErr.AllMessage())
 	assert.NotEmpty(t, appErr.StackTrace)
 	assert.Equal(t, "TestNew", appErr.StackTrace[0].Func)
 }
@@ -25,7 +25,7 @@ func TestErrorf(t *testing.T) {
 
 	appErr := Unwrap(err)
 	assert.Equal(t, err.Error(), appErr.Err.Error())
-	assert.Equal(t, "", appErr.Message)
+	assert.Equal(t, "", appErr.AllMessage())
 	assert.NotEmpty(t, appErr.StackTrace)
 	assert.Equal(t, "TestErrorf", appErr.StackTrace[0].Func)
 }
@@ -44,7 +44,7 @@ func TestWithMessage(t *testing.T) {
 
 		appErr := Unwrap(err1)
 		assert.Equal(t, err0, appErr.Err)
-		assert.Equal(t, err1.Error(), appErr.Message)
+		assert.Equal(t, err1.Error(), appErr.AllMessage())
 	})
 
 	t.Run("already wrapped", func(t *testing.T) {
@@ -52,7 +52,7 @@ func TestWithMessage(t *testing.T) {
 
 		err1 := &Error{
 			Err:        err0,
-			Message:    "message 1",
+			Messages:   []string{"message 1"},
 			StatusCode: 400,
 		}
 		err2 := Wrap(err1, WithMessage("message 2"))
@@ -61,14 +61,14 @@ func TestWithMessage(t *testing.T) {
 		{
 			appErr := Unwrap(err1)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, err1.Error(), appErr.Message)
+			assert.Equal(t, err1.Error(), appErr.AllMessage())
 			assert.Equal(t, 400, appErr.StatusCode)
 		}
 
 		{
 			appErr := Unwrap(err2)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, err2.Error(), appErr.Message)
+			assert.Equal(t, err2.Error(), appErr.AllMessage())
 			assert.Equal(t, 400, appErr.StatusCode)
 		}
 	})
@@ -87,7 +87,7 @@ func TestWithStatusCode(t *testing.T) {
 
 		appErr := Unwrap(err1)
 		assert.Equal(t, err0, appErr.Err)
-		assert.Equal(t, "", appErr.Message)
+		assert.Equal(t, "", appErr.AllMessage())
 	})
 
 	t.Run("already wrapped", func(t *testing.T) {
@@ -95,7 +95,7 @@ func TestWithStatusCode(t *testing.T) {
 
 		err1 := &Error{
 			Err:        err0,
-			Message:    "message 1",
+			Messages:   []string{"message 1"},
 			StatusCode: 400,
 		}
 		err2 := Wrap(err1, WithStatusCode(500))
@@ -103,14 +103,14 @@ func TestWithStatusCode(t *testing.T) {
 		{
 			appErr := Unwrap(err1)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, err1.Error(), appErr.Message)
+			assert.Equal(t, err1.Error(), appErr.AllMessage())
 			assert.Equal(t, 400, appErr.StatusCode)
 		}
 
 		{
 			appErr := Unwrap(err2)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, err1.Error(), appErr.Message)
+			assert.Equal(t, err1.Error(), appErr.AllMessage())
 			assert.Equal(t, 500, appErr.StatusCode)
 		}
 	})
@@ -211,7 +211,7 @@ func TestWithIgnorable(t *testing.T) {
 
 		appErr := Unwrap(err1)
 		assert.Equal(t, err0, appErr.Err)
-		assert.Equal(t, "", appErr.Message)
+		assert.Equal(t, "", appErr.AllMessage())
 	})
 
 	t.Run("already wrapped", func(t *testing.T) {
@@ -255,7 +255,7 @@ func TestWrap(t *testing.T) {
 
 		appErr := Unwrap(err1)
 		assert.Equal(t, err0, appErr.Err)
-		assert.Equal(t, "", appErr.Message)
+		assert.Equal(t, "", appErr.AllMessage())
 		assert.NotEmpty(t, appErr.StackTrace)
 		assert.Equal(t, "wrapOrigin", appErr.StackTrace[0].Func)
 	})
@@ -269,7 +269,7 @@ func TestWrap(t *testing.T) {
 
 		appErr := Unwrap(err2)
 		assert.Equal(t, err0, appErr.Err)
-		assert.Equal(t, "", appErr.Message)
+		assert.Equal(t, "", appErr.AllMessage())
 		assert.NotEmpty(t, appErr.StackTrace)
 		assert.Equal(t, "wrapOrigin", appErr.StackTrace[0].Func)
 	})
@@ -283,7 +283,7 @@ func TestWrap(t *testing.T) {
 
 			appErr := Unwrap(err1)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, "", appErr.Message)
+			assert.Equal(t, "", appErr.AllMessage())
 			assert.NotEmpty(t, appErr.StackTrace)
 			assert.Equal(t, "pkgErrorsNew", appErr.StackTrace[0].Func)
 		})
@@ -297,7 +297,7 @@ func TestWrap(t *testing.T) {
 
 			appErr := Unwrap(err2)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, "message: original", appErr.Message)
+			assert.Equal(t, "message: original", appErr.AllMessage())
 			assert.NotEmpty(t, appErr.StackTrace)
 			assert.Equal(t, "pkgErrorsWrap", appErr.StackTrace[0].Func)
 		})
@@ -307,7 +307,7 @@ func TestWrap(t *testing.T) {
 func TestAll(t *testing.T) {
 	{
 		appErr := Unwrap(errFunc3())
-		assert.Equal(t, "e2: e1: e0", appErr.Message)
+		assert.Equal(t, "e2: e1: e0", appErr.AllMessage())
 		assert.Equal(t, nil, appErr.StatusCode)
 		assert.Equal(t, false, appErr.Ignorable)
 		assert.NotEmpty(t, appErr.StackTrace)
@@ -316,7 +316,7 @@ func TestAll(t *testing.T) {
 
 	{
 		appErr := Unwrap(errFunc4())
-		assert.Equal(t, "e4", appErr.Message)
+		assert.Equal(t, "e4", appErr.AllMessage())
 		assert.Equal(t, 500, appErr.StatusCode)
 		assert.Equal(t, true, appErr.Ignorable)
 		assert.NotEmpty(t, appErr.StackTrace)

--- a/error_test.go
+++ b/error_test.go
@@ -56,7 +56,7 @@ func TestWithMessage(t *testing.T) {
 			StatusCode: 400,
 		}
 		err2 := Wrap(err1, WithMessage("message 2"))
-		assert.Equal(t, "message 1: message 2", err2.Error())
+		assert.Equal(t, "message 2: message 1", err2.Error())
 
 		{
 			appErr := Unwrap(err1)
@@ -316,7 +316,7 @@ func TestAll(t *testing.T) {
 
 	{
 		appErr := Unwrap(errFunc4())
-		assert.Equal(t, "e2: e1: e0: e4", appErr.AllMessage())
+		assert.Equal(t, "e4: e2: e1: e0", appErr.AllMessage())
 		assert.Equal(t, 500, appErr.StatusCode)
 		assert.Equal(t, true, appErr.Ignorable)
 		assert.NotEmpty(t, appErr.StackTrace)

--- a/error_test.go
+++ b/error_test.go
@@ -14,7 +14,7 @@ func TestNew(t *testing.T) {
 
 	appErr := Unwrap(err)
 	assert.Equal(t, err.Error(), appErr.Err.Error())
-	assert.Equal(t, "", appErr.AllMessage())
+	assert.Equal(t, "", appErr.FullMessage())
 	assert.NotEmpty(t, appErr.StackTrace)
 	assert.Equal(t, "TestNew", appErr.StackTrace[0].Func)
 }
@@ -25,7 +25,7 @@ func TestErrorf(t *testing.T) {
 
 	appErr := Unwrap(err)
 	assert.Equal(t, err.Error(), appErr.Err.Error())
-	assert.Equal(t, "", appErr.AllMessage())
+	assert.Equal(t, "", appErr.FullMessage())
 	assert.NotEmpty(t, appErr.StackTrace)
 	assert.Equal(t, "TestErrorf", appErr.StackTrace[0].Func)
 }
@@ -44,7 +44,7 @@ func TestWithMessage(t *testing.T) {
 
 		appErr := Unwrap(err1)
 		assert.Equal(t, err0, appErr.Err)
-		assert.Equal(t, err1.Error(), appErr.AllMessage())
+		assert.Equal(t, err1.Error(), appErr.FullMessage())
 	})
 
 	t.Run("already wrapped", func(t *testing.T) {
@@ -61,14 +61,14 @@ func TestWithMessage(t *testing.T) {
 		{
 			appErr := Unwrap(err1)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, err1.Error(), appErr.AllMessage())
+			assert.Equal(t, err1.Error(), appErr.FullMessage())
 			assert.Equal(t, 400, appErr.StatusCode)
 		}
 
 		{
 			appErr := Unwrap(err2)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, err2.Error(), appErr.AllMessage())
+			assert.Equal(t, err2.Error(), appErr.FullMessage())
 			assert.Equal(t, 400, appErr.StatusCode)
 		}
 	})
@@ -87,7 +87,7 @@ func TestWithStatusCode(t *testing.T) {
 
 		appErr := Unwrap(err1)
 		assert.Equal(t, err0, appErr.Err)
-		assert.Equal(t, "", appErr.AllMessage())
+		assert.Equal(t, "", appErr.FullMessage())
 	})
 
 	t.Run("already wrapped", func(t *testing.T) {
@@ -103,14 +103,14 @@ func TestWithStatusCode(t *testing.T) {
 		{
 			appErr := Unwrap(err1)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, err1.Error(), appErr.AllMessage())
+			assert.Equal(t, err1.Error(), appErr.FullMessage())
 			assert.Equal(t, 400, appErr.StatusCode)
 		}
 
 		{
 			appErr := Unwrap(err2)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, err1.Error(), appErr.AllMessage())
+			assert.Equal(t, err1.Error(), appErr.FullMessage())
 			assert.Equal(t, 500, appErr.StatusCode)
 		}
 	})
@@ -211,7 +211,7 @@ func TestWithIgnorable(t *testing.T) {
 
 		appErr := Unwrap(err1)
 		assert.Equal(t, err0, appErr.Err)
-		assert.Equal(t, "", appErr.AllMessage())
+		assert.Equal(t, "", appErr.FullMessage())
 	})
 
 	t.Run("already wrapped", func(t *testing.T) {
@@ -255,7 +255,7 @@ func TestWrap(t *testing.T) {
 
 		appErr := Unwrap(err1)
 		assert.Equal(t, err0, appErr.Err)
-		assert.Equal(t, "", appErr.AllMessage())
+		assert.Equal(t, "", appErr.FullMessage())
 		assert.NotEmpty(t, appErr.StackTrace)
 		assert.Equal(t, "wrapOrigin", appErr.StackTrace[0].Func)
 	})
@@ -269,7 +269,7 @@ func TestWrap(t *testing.T) {
 
 		appErr := Unwrap(err2)
 		assert.Equal(t, err0, appErr.Err)
-		assert.Equal(t, "", appErr.AllMessage())
+		assert.Equal(t, "", appErr.FullMessage())
 		assert.NotEmpty(t, appErr.StackTrace)
 		assert.Equal(t, "wrapOrigin", appErr.StackTrace[0].Func)
 	})
@@ -283,7 +283,7 @@ func TestWrap(t *testing.T) {
 
 			appErr := Unwrap(err1)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, "", appErr.AllMessage())
+			assert.Equal(t, "", appErr.FullMessage())
 			assert.NotEmpty(t, appErr.StackTrace)
 			assert.Equal(t, "pkgErrorsNew", appErr.StackTrace[0].Func)
 		})
@@ -297,7 +297,7 @@ func TestWrap(t *testing.T) {
 
 			appErr := Unwrap(err2)
 			assert.Equal(t, err0, appErr.Err)
-			assert.Equal(t, "message: original", appErr.AllMessage())
+			assert.Equal(t, "message: original", appErr.FullMessage())
 			assert.NotEmpty(t, appErr.StackTrace)
 			assert.Equal(t, "pkgErrorsWrap", appErr.StackTrace[0].Func)
 		})
@@ -307,7 +307,7 @@ func TestWrap(t *testing.T) {
 func TestAll(t *testing.T) {
 	{
 		appErr := Unwrap(errFunc3())
-		assert.Equal(t, "e2: e1: e0", appErr.AllMessage())
+		assert.Equal(t, "e2: e1: e0", appErr.FullMessage())
 		assert.Equal(t, nil, appErr.StatusCode)
 		assert.Equal(t, false, appErr.Ignorable)
 		assert.NotEmpty(t, appErr.StackTrace)
@@ -316,7 +316,7 @@ func TestAll(t *testing.T) {
 
 	{
 		appErr := Unwrap(errFunc4())
-		assert.Equal(t, "e4: e2: e1: e0", appErr.AllMessage())
+		assert.Equal(t, "e4: e2: e1: e0", appErr.FullMessage())
 		assert.Equal(t, 500, appErr.StatusCode)
 		assert.Equal(t, true, appErr.Ignorable)
 		assert.NotEmpty(t, appErr.StackTrace)

--- a/error_test.go
+++ b/error_test.go
@@ -30,6 +30,22 @@ func TestErrorf(t *testing.T) {
 	assert.Equal(t, "TestErrorf", appErr.StackTrace[0].Func)
 }
 
+func TestError_LastMessage(t *testing.T) {
+	err := &Error{
+		Err:      errors.New("err"),
+		Messages: []string{"message 2", "message 1"},
+	}
+	assert.Equal(t, "message 2", err.LastMessage())
+}
+
+func TestError_FullMessage(t *testing.T) {
+	err := &Error{
+		Err:      errors.New("err"),
+		Messages: []string{"message 2", "message 1"},
+	}
+	assert.Equal(t, "message 2: message 1", err.FullMessage())
+}
+
 func TestWithMessage(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		err := Wrap(nil, WithMessage("message"))

--- a/error_test.go
+++ b/error_test.go
@@ -56,7 +56,7 @@ func TestWithMessage(t *testing.T) {
 			StatusCode: 400,
 		}
 		err2 := Wrap(err1, WithMessage("message 2"))
-		assert.Equal(t, "message 2", err2.Error())
+		assert.Equal(t, "message 1: message 2", err2.Error())
 
 		{
 			appErr := Unwrap(err1)
@@ -316,7 +316,7 @@ func TestAll(t *testing.T) {
 
 	{
 		appErr := Unwrap(errFunc4())
-		assert.Equal(t, "e4", appErr.AllMessage())
+		assert.Equal(t, "e2: e1: e0: e4", appErr.AllMessage())
 		assert.Equal(t, 500, appErr.StatusCode)
 		assert.Equal(t, true, appErr.Ignorable)
 		assert.NotEmpty(t, appErr.StackTrace)

--- a/options.go
+++ b/options.go
@@ -9,7 +9,7 @@ func WithMessage(msg string) Option {
 		if msg == "" {
 			return
 		}
-		err.Messages = append(err.Messages, msg)
+		err.Messages = append([]string{msg}, err.Messages...)
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -6,7 +6,7 @@ type Option func(*Error)
 // WithMessage annotates with the message.
 func WithMessage(msg string) Option {
 	return func(err *Error) {
-		err.Message = msg
+		err.Messages = append(err.Messages, msg)
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -6,6 +6,9 @@ type Option func(*Error)
 // WithMessage annotates with the message.
 func WithMessage(msg string) Option {
 	return func(err *Error) {
+		if msg == "" {
+			return
+		}
 		err.Messages = append(err.Messages, msg)
 	}
 }


### PR DESCRIPTION
## Why

Change internal data structure from a string to an array of strings to retain all messages.