### PR TITLE
Create a virtual stack trace by merging multiple stack traces

### DIFF
--- a/pkgerrors.go
+++ b/pkgerrors.go
@@ -1,9 +1,6 @@
 package fail
 
 import (
-	//"fmt"
-	//"strconv"
-
 	pkgerrors "github.com/pkg/errors"
 )
 
@@ -55,15 +52,10 @@ func extractPkgError(err error) pkgError {
 
 // convertStackTrace converts pkg/errors.StackTrace into fail.StackTrace
 func convertStackTrace(stackTrace pkgerrors.StackTrace) (frames StackTrace) {
-	if stackTrace == nil {
-		return
-	}
-
 	for _, t := range stackTrace {
 		if frame, ok := newFrameFrom(uintptr(t)); ok {
 			frames = append(frames, frame)
 		}
 	}
-
 	return
 }

--- a/pkgerrors.go
+++ b/pkgerrors.go
@@ -30,7 +30,7 @@ func extractPkgError(err error) pkgError {
 	for {
 		if t, ok := rootErr.(traceable); ok {
 			stackTrace := convertStackTrace(t.StackTrace())
-			stackTraces = append([]StackTrace{stackTrace}, stackTraces...)
+			stackTraces = append(stackTraces, stackTrace)
 		}
 
 		if cause, ok := rootErr.(causer); ok {
@@ -41,11 +41,6 @@ func extractPkgError(err error) pkgError {
 		break
 	}
 
-	var stackTrace StackTrace
-	if len(stackTraces) > 0 {
-		stackTrace = stackTraces[0] // TODO
-	}
-
 	var msg string
 	if err.Error() != rootErr.Error() {
 		msg = err.Error()
@@ -54,7 +49,7 @@ func extractPkgError(err error) pkgError {
 	return pkgError{
 		Err:        rootErr,
 		Message:    msg,
-		StackTrace: stackTrace,
+		StackTrace: reduceStackTraces(stackTraces),
 	}
 }
 

--- a/pkgerrors.go
+++ b/pkgerrors.go
@@ -1,8 +1,8 @@
 package fail
 
 import (
-	"fmt"
-	"strconv"
+	//"fmt"
+	//"strconv"
 
 	pkgerrors "github.com/pkg/errors"
 )
@@ -60,15 +60,9 @@ func convertStackTrace(stackTrace pkgerrors.StackTrace) (frames StackTrace) {
 	}
 
 	for _, t := range stackTrace {
-		file := fmt.Sprintf("%s", t)
-		line, _ := strconv.ParseInt(fmt.Sprintf("%d", t), 10, 64)
-		funcName := fmt.Sprintf("%n", t)
-
-		frames = append(frames, Frame{
-			Func: funcName,
-			Line: line,
-			File: file,
-		})
+		if frame, ok := newFrameFrom(uintptr(t)); ok {
+			frames = append(frames, frame)
+		}
 	}
 
 	return

--- a/stack.go
+++ b/stack.go
@@ -138,3 +138,12 @@ func mergeStackTraces(inner StackTrace, outer StackTrace) StackTrace {
 
 	return append(inner, outer...)
 }
+
+// reduceStackTraces incrementally merges multiple stack traces
+// and returns a merged stack trace
+func reduceStackTraces(stackTraces []StackTrace) (merged StackTrace) {
+	for i := len(stackTraces) - 1; i >= 0; i-- {
+		merged = mergeStackTraces(merged, stackTraces[i])
+	}
+	return
+}

--- a/stack.go
+++ b/stack.go
@@ -1,7 +1,6 @@
 package fail
 
 import (
-	"fmt"
 	"runtime"
 	"strings"
 )
@@ -19,10 +18,6 @@ type Frame struct {
 	Func string
 	File string
 	Line int64
-}
-
-func (f Frame) hash() string {
-	return fmt.Sprintf("%s:%s:%d", f.Func, f.File, f.Line)
 }
 
 // newFrameFrom creates Frame from the specified program counter
@@ -122,7 +117,7 @@ func mergeStackTraces(inner StackTrace, outer StackTrace) StackTrace {
 	if innerLen > outerLen {
 		overlap := 0
 		for overlap < outerLen {
-			if inner[innerLen-overlap-1].hash() != outer[outerLen-overlap-1].hash() {
+			if inner[innerLen-overlap-1] != outer[outerLen-overlap-1] {
 				break
 			}
 			overlap++

--- a/stack_test.go
+++ b/stack_test.go
@@ -134,3 +134,36 @@ func TestMergeStackTraces(t *testing.T) {
 		assert.Equal(t, result, mergeStackTraces(inner, outer))
 	})
 }
+
+func TestReduceStackTraces(t *testing.T) {
+	input := []StackTrace{
+		{
+			{Func: "main", File: "main.go", Line: 179},
+		},
+		{
+			{Func: "f3.func1", File: "main.go", Line: 168},
+		},
+		{
+			{Func: "f2", File: "main.go", Line: 162},
+			{Func: "f3.func1", File: "main.go", Line: 168},
+		},
+		{
+			{Func: "f1", File: "main.go", Line: 158},
+			{Func: "f2", File: "main.go", Line: 162},
+			{Func: "f3.func1", File: "main.go", Line: 168},
+		},
+		{
+			{Func: "init", File: "main.go", Line: 155},
+		},
+		{},
+	}
+	result := StackTrace{
+		{Func: "init", File: "main.go", Line: 155},
+		{Func: "f1", File: "main.go", Line: 158},
+		{Func: "f2", File: "main.go", Line: 162},
+		{Func: "f3.func1", File: "main.go", Line: 168},
+		{Func: "main", File: "main.go", Line: 179},
+	}
+
+	assert.Equal(t, result, reduceStackTraces(input))
+}

--- a/stack_test.go
+++ b/stack_test.go
@@ -57,3 +57,80 @@ func TestTrimGOPATH(t *testing.T) {
 
 	assert.Equal(t, "pkg/sub/file.go", trimGOPATH(funcName, file))
 }
+
+func TestMergeStackTraces(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		inner := StackTrace{}
+		outer := StackTrace{
+			{Func: "init", File: "main.go", Line: 154},
+		}
+		result := StackTrace{
+			{Func: "init", File: "main.go", Line: 154},
+		}
+
+		assert.Equal(t, result, mergeStackTraces(inner, outer))
+	})
+
+	t.Run("inner < outer", func(t *testing.T) {
+		inner := StackTrace{
+			{Func: "init", File: "main.go", Line: 154},
+		}
+		outer := StackTrace{
+			{Func: "f1", File: "main.go", Line: 157},
+			{Func: "f2", File: "main.go", Line: 161},
+			{Func: "f3.func1", File: "main.go", Line: 167},
+		}
+		result := StackTrace{
+			{Func: "init", File: "main.go", Line: 154},
+			{Func: "f1", File: "main.go", Line: 157},
+			{Func: "f2", File: "main.go", Line: 161},
+			{Func: "f3.func1", File: "main.go", Line: 167},
+		}
+
+		assert.Equal(t, result, mergeStackTraces(inner, outer))
+	})
+
+	t.Run("inner > outer (overlapping)", func(t *testing.T) {
+		inner := StackTrace{
+			{Func: "init", File: "main.go", Line: 154},
+			{Func: "f1", File: "main.go", Line: 157},
+			{Func: "f2", File: "main.go", Line: 161},
+			{Func: "f3.func1", File: "main.go", Line: 167},
+		}
+		outer := StackTrace{
+			{Func: "f2", File: "main.go", Line: 161},
+			{Func: "f3.func1", File: "main.go", Line: 167},
+		}
+		result := StackTrace{
+			{Func: "init", File: "main.go", Line: 154},
+			{Func: "f1", File: "main.go", Line: 157},
+			{Func: "f2", File: "main.go", Line: 161},
+			{Func: "f3.func1", File: "main.go", Line: 167},
+		}
+
+		assert.Equal(t, result, mergeStackTraces(inner, outer))
+	})
+
+	t.Run("inner > outer (no overlapping frames)", func(t *testing.T) {
+		inner := StackTrace{
+			{Func: "init", File: "main.go", Line: 154},
+			{Func: "f1", File: "main.go", Line: 157},
+			{Func: "f2", File: "main.go", Line: 161},
+			{Func: "f3.func1", File: "main.go", Line: 167},
+		}
+		outer := StackTrace{
+			{Func: "g2", File: "main.go", Line: 1061},
+			{Func: "g3.func1", File: "main.go", Line: 1067},
+		}
+		result := StackTrace{
+			{Func: "init", File: "main.go", Line: 154},
+			{Func: "f1", File: "main.go", Line: 157},
+			{Func: "f2", File: "main.go", Line: 161},
+			{Func: "f3.func1", File: "main.go", Line: 167},
+			{Func: "g2", File: "main.go", Line: 1061},
+			{Func: "g3.func1", File: "main.go", Line: 1067},
+		}
+
+		assert.Equal(t, result, mergeStackTraces(inner, outer))
+	})
+}


### PR DESCRIPTION
## Why

> The only scenario where multiple stack traces might be useful is when an error is passed between goroutines (and thus jumps stacks) before getting handled.

https://github.com/pkg/errors/issues/75

However, this data structure makes it difficult to grasp the flow, and in most cases, it's not compatible with error reporting services.

## What

Instead of retaining all stack traces, it creates a *virtual* stack trace.
It retrives stack trace on every wrap just as pkg/errors does and merges that with the underlying stack trace of the given error.
