### PR TITLE
Fix doc

### DIFF
--- a/annotators.go
+++ b/annotators.go
@@ -45,3 +45,12 @@ func WithParams(h H) Annotator {
 		err.Params = err.Params.Merge(h)
 	}
 }
+
+// withStackTrace returns an annotator that sets a stack trace to Error
+func withStackTrace(offset int) Annotator {
+	stackTrace := newStackTrace(offset + 1)
+
+	return func(err *Error) {
+		err.StackTrace = mergeStackTraces(err.StackTrace, stackTrace)
+	}
+}

--- a/annotators.go
+++ b/annotators.go
@@ -1,9 +1,9 @@
 package fail
 
-// Annotator is a function that annotates an error with information.
+// Annotator is a function that annotates an error with information
 type Annotator func(*Error)
 
-// WithMessage annotates with the message.
+// WithMessage annotates an error with the message
 func WithMessage(msg string) Annotator {
 	return func(err *Error) {
 		if msg == "" {
@@ -13,40 +13,40 @@ func WithMessage(msg string) Annotator {
 	}
 }
 
-// WithCode annotates with the code.
+// WithCode annotates an error with the code
 func WithCode(code interface{}) Annotator {
 	return func(err *Error) {
 		err.Code = code
 	}
 }
 
-// WithIgnorable annotates with the reportability.
+// WithIgnorable annotates an error with the reportability
 func WithIgnorable() Annotator {
 	return func(err *Error) {
 		err.Ignorable = true
 	}
 }
 
-// WithTags annotates with tags.
+// WithTags annotates an error with tags
 func WithTags(tags ...string) Annotator {
 	return func(err *Error) {
 		err.Tags = append(err.Tags, tags...)
 	}
 }
 
-// WithParam annotates with a key-value pair.
+// WithParam annotates an error with a key-value pair
 func WithParam(key string, value interface{}) Annotator {
 	return WithParams(H{key: value})
 }
 
-// WithParams annotates with key-value pairs.
+// WithParams annotates an error with key-value pairs
 func WithParams(h H) Annotator {
 	return func(err *Error) {
 		err.Params = err.Params.Merge(h)
 	}
 }
 
-// withStackTrace returns an annotator that sets a stack trace to Error
+// withStackTrace annotates an error with the stack trace from the point it was called
 func withStackTrace(offset int) Annotator {
 	stackTrace := newStackTrace(offset + 1)
 

--- a/annotators.go
+++ b/annotators.go
@@ -1,10 +1,10 @@
 package fail
 
-// Option annotates an errors.
-type Option func(*Error)
+// Annotator is a function that annotates an error with information.
+type Annotator func(*Error)
 
 // WithMessage annotates with the message.
-func WithMessage(msg string) Option {
+func WithMessage(msg string) Annotator {
 	return func(err *Error) {
 		if msg == "" {
 			return
@@ -14,33 +14,33 @@ func WithMessage(msg string) Option {
 }
 
 // WithCode annotates with the code.
-func WithCode(code interface{}) Option {
+func WithCode(code interface{}) Annotator {
 	return func(err *Error) {
 		err.Code = code
 	}
 }
 
 // WithIgnorable annotates with the reportability.
-func WithIgnorable() Option {
+func WithIgnorable() Annotator {
 	return func(err *Error) {
 		err.Ignorable = true
 	}
 }
 
 // WithTags annotates with tags.
-func WithTags(tags ...string) Option {
+func WithTags(tags ...string) Annotator {
 	return func(err *Error) {
 		err.Tags = append(err.Tags, tags...)
 	}
 }
 
 // WithParam annotates with a key-value pair.
-func WithParam(key string, value interface{}) Option {
+func WithParam(key string, value interface{}) Annotator {
 	return WithParams(H{key: value})
 }
 
 // WithParams annotates with key-value pairs.
-func WithParams(h H) Option {
+func WithParams(h H) Annotator {
 	return func(err *Error) {
 		err.Params = err.Params.Merge(h)
 	}

--- a/error.go
+++ b/error.go
@@ -82,16 +82,17 @@ func (e *Error) FullMessage() string {
 	return strings.Join(e.Messages, messageDelimiter)
 }
 
-// Wrap returns an error annotated with a stack trace from the point it was called.
-// It returns nil if err is nil
-func Wrap(err error, opts ...Option) error {
+// Wrap returns an error annotated with a stack trace from the point it was called,
+// and with the specified annotators.
+// It returns nil if err is nil.
+func Wrap(err error, annotators ...Annotator) error {
 	if err == nil {
 		return nil
 	}
 
 	appErr := wrap(err)
 
-	for _, f := range opts {
+	for _, f := range annotators {
 		f(appErr)
 	}
 

--- a/error.go
+++ b/error.go
@@ -30,7 +30,7 @@ type Error struct {
 }
 
 // New returns an error that formats as the given text.
-// It also annotates the error with a stack trace from the point it was called
+// It also records the stack trace at the point it was called.
 func New(text string) error {
 	err := &Error{Err: errors.New(text)}
 	withStackTrace(0)(err)
@@ -39,7 +39,7 @@ func New(text string) error {
 
 // Errorf formats according to a format specifier and returns the string
 // as a value that satisfies error.
-// It also annotates the error with a stack trace from the point it was called
+// It also records the stack trace at the point it was called.
 func Errorf(format string, args ...interface{}) error {
 	err := &Error{Err: fmt.Errorf(format, args...)}
 	withStackTrace(0)(err)

--- a/error.go
+++ b/error.go
@@ -32,20 +32,18 @@ type Error struct {
 // New returns an error that formats as the given text.
 // It also annotates the error with a stack trace from the point it was called
 func New(text string) error {
-	return &Error{
-		Err:        errors.New(text),
-		StackTrace: newStackTrace(0),
-	}
+	err := &Error{Err: errors.New(text)}
+	withStackTrace(0)(err)
+	return err
 }
 
 // Errorf formats according to a format specifier and returns the string
 // as a value that satisfies error.
 // It also annotates the error with a stack trace from the point it was called
 func Errorf(format string, args ...interface{}) error {
-	return &Error{
-		Err:        fmt.Errorf(format, args...),
-		StackTrace: newStackTrace(0),
-	}
+	err := &Error{Err: fmt.Errorf(format, args...)}
+	withStackTrace(0)(err)
+	return err
 }
 
 // Error implements error interface
@@ -100,8 +98,6 @@ func Wrap(err error, annotators ...Annotator) error {
 }
 
 func wrap(err error) (wrappedErr *Error) {
-	stackTrace := newStackTrace(1)
-
 	pkgErr := extractPkgError(err)
 	if appErr, ok := pkgErr.Err.(*Error); ok {
 		wrappedErr = appErr.Copy()
@@ -113,7 +109,7 @@ func wrap(err error) (wrappedErr *Error) {
 		WithMessage(pkgErr.Message)(wrappedErr)
 	}
 
-	wrappedErr.StackTrace = mergeStackTraces(wrappedErr.StackTrace, stackTrace)
+	withStackTrace(1)(wrappedErr)
 
 	return
 }


### PR DESCRIPTION
## Why

Some information is outdated due to recent changes.

## What

- Update README
- Tweak godoc
- Rename Option type to Annotator