### PR TITLE
Fix broken stack traces with Go v1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go:       1.11
+go:       1.12
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
-go:       1.12
+
+matrix:
+ include:
+  - go: '1.11'
+  - go: '1.12'
 
 branches:
   only:

--- a/pkgerrors.go
+++ b/pkgerrors.go
@@ -57,11 +57,10 @@ func extractPkgError(err error) pkgError {
 }
 
 // convertStackTrace converts pkg/errors.StackTrace into fail.StackTrace
-func convertStackTrace(stackTrace pkgerrors.StackTrace) (frames StackTrace) {
-	for _, t := range stackTrace {
-		if frame, ok := newFrameFrom(uintptr(t)); ok {
-			frames = append(frames, frame)
-		}
+func convertStackTrace(stackTrace pkgerrors.StackTrace) StackTrace {
+	pcs := make([]uintptr, len(stackTrace))
+	for i, t := range stackTrace {
+		pcs[i] = uintptr(t)
 	}
-	return
+	return newStackTraceFromPCs(pcs)
 }


### PR DESCRIPTION
## Why

https://golang.org/doc/go1.12#runtime

> Tracebacks, `runtime.Caller`, and `runtime.Callers` no longer include compiler-generated initialization functions. Doing a traceback during the initialization of a global variable will now show a function named `PKG.init.ializers`.

https://golang.org/doc/go1.12#compiler

> More functions are now eligible for inlining by default, including functions that do nothing but call another function. This extra inlining makes it additionally important to use `runtime.CallersFrames` instead of iterating over the result of `runtime.Callers` directly.
> [...]
> Wrappers generated by the compiler to implement method expressions are no longer reported by `runtime.CallersFrames` and `runtime.Stack`. They are also not printed in panic stack traces. This change aligns the gc toolchain to match the `gccgo` toolchain, which already elided such wrappers from stack traces. Clients of these APIs might need to adjust for the missing frames. For code that must interoperate between 1.11 and 1.12 releases, you can replace the method expression `x.M` with the function literal `func (...) { x.M(...) }` .

See this build:
https://travis-ci.com/srvc/fail/builds/105544372

## What

Factorize the traceback logic to use `runtime.CallersFrames` which is introduced in Go v1.7.