### PR TITLE
Make `pkg/errors` eligible for `Unwrap` 

### DIFF
--- a/error.go
+++ b/error.go
@@ -109,7 +109,9 @@ func wrap(err error) (wrappedErr *Error) {
 		}
 	}
 
-	WithMessage(pkgErr.Message)(wrappedErr)
+	for i := len(pkgErr.Messages) - 1; i >= 0; i-- {
+		WithMessage(pkgErr.Messages[i])(wrappedErr)
+	}
 	withStackTrace(1)(wrappedErr)
 
 	return
@@ -131,7 +133,9 @@ func Unwrap(err error) (unwrapped *Error) {
 	if appErr, ok := pkgErr.Err.(*Error); ok {
 		appErr = appErr.Copy()
 		appErr.StackTrace = mergeStackTraces(appErr.StackTrace, pkgErr.StackTrace)
-		WithMessage(pkgErr.Message)(appErr)
+		for i := len(pkgErr.Messages) - 1; i >= 0; i-- {
+			WithMessage(pkgErr.Messages[i])(appErr)
+		}
 		return appErr
 	}
 

--- a/error_test.go
+++ b/error_test.go
@@ -406,6 +406,19 @@ func TestAll(t *testing.T) {
 			"tRunner",
 		}, funcNamesFromStackTrace(appErr.StackTrace))
 	}
+
+	{
+		appErr := Unwrap(errFunc0e1p2p3f4p())
+		assert.Equal(t, "4p: 2p: 1p: 0e", appErr.Error())
+		assert.Equal(t, []string{
+			"errFunc0e1p",
+			"errFunc0e1p2p",
+			"errFunc0e1p2p3f",
+			"errFunc0e1p2p3f4p",
+			"TestAll",
+			"tRunner",
+		}, funcNamesFromStackTrace(appErr.StackTrace))
+	}
 }
 
 func wrapOrigin(err error) error {
@@ -456,4 +469,8 @@ func errFunc0e1p2p3fg() chan error {
 }
 func errFunc0e1p2p3fg4f() error {
 	return Wrap(<-errFunc0e1p2p3fg(), WithMessage("4f"), WithCode(500), WithIgnorable())
+}
+
+func errFunc0e1p2p3f4p() error {
+	return pkgerrors.Wrap(errFunc0e1p2p3f(), "4p")
 }

--- a/error_test.go
+++ b/error_test.go
@@ -363,7 +363,7 @@ func TestWrap(t *testing.T) {
 }
 
 func TestAll(t *testing.T) {
-	{
+	t.Run("e-p-p-f", func(t *testing.T) {
 		appErr := Unwrap(errFunc0e1p2p3f())
 		assert.Equal(t, "2p: 1p: 0e", appErr.Error())
 		assert.Equal(t, nil, appErr.Code)
@@ -372,12 +372,12 @@ func TestAll(t *testing.T) {
 			"errFunc0e1p",
 			"errFunc0e1p2p",
 			"errFunc0e1p2p3f",
-			"TestAll",
+			"TestAll.func1",
 			"tRunner",
 		}, funcNamesFromStackTrace(appErr.StackTrace))
-	}
+	})
 
-	{
+	t.Run("e-p-p-f-f", func(t *testing.T) {
 		appErr := Unwrap(errFunc0e1p2p3f4f())
 		assert.Equal(t, "4f: 2p: 1p: 0e", appErr.Error())
 		assert.Equal(t, 500, appErr.Code)
@@ -387,12 +387,12 @@ func TestAll(t *testing.T) {
 			"errFunc0e1p2p",
 			"errFunc0e1p2p3f",
 			"errFunc0e1p2p3f4f",
-			"TestAll",
+			"TestAll.func2",
 			"tRunner",
 		}, funcNamesFromStackTrace(appErr.StackTrace))
-	}
+	})
 
-	{
+	t.Run("e-p-p-fg-f", func(t *testing.T) {
 		appErr := Unwrap(errFunc0e1p2p3fg4f())
 		assert.Equal(t, "4f: 2p: 1p: 0e", appErr.Error())
 		assert.Equal(t, 500, appErr.Code)
@@ -402,12 +402,12 @@ func TestAll(t *testing.T) {
 			"errFunc0e1p2p",
 			"errFunc0e1p2p3fg.func1",
 			"errFunc0e1p2p3fg4f",
-			"TestAll",
+			"TestAll.func3",
 			"tRunner",
 		}, funcNamesFromStackTrace(appErr.StackTrace))
-	}
+	})
 
-	{
+	t.Run("e-p-p-f-p", func(t *testing.T) {
 		appErr := Unwrap(errFunc0e1p2p3f4p())
 		assert.Equal(t, "4p: 2p: 1p: 0e", appErr.Error())
 		assert.Equal(t, []string{
@@ -415,10 +415,37 @@ func TestAll(t *testing.T) {
 			"errFunc0e1p2p",
 			"errFunc0e1p2p3f",
 			"errFunc0e1p2p3f4p",
-			"TestAll",
+			"TestAll.func4",
 			"tRunner",
 		}, funcNamesFromStackTrace(appErr.StackTrace))
-	}
+	})
+
+	t.Run("e-p-p-fg-f-p", func(t *testing.T) {
+		appErr := Unwrap(errFunc0e1p2p3fg4f5p())
+		assert.Equal(t, "5p: 4f: 2p: 1p: 0e", appErr.Error())
+		assert.Equal(t, []string{
+			"errFunc0e1p",
+			"errFunc0e1p2p",
+			"errFunc0e1p2p3fg.func1",
+			"errFunc0e1p2p3fg4f",
+			"errFunc0e1p2p3fg4f5p",
+			"TestAll.func5",
+			"tRunner",
+		}, funcNamesFromStackTrace(appErr.StackTrace))
+	})
+
+	t.Run("e-p-p-pg-p", func(t *testing.T) {
+		appErr := Unwrap(errFunc0e1p2p3pg4p())
+		assert.Equal(t, "4p: 3pg: 2p: 1p: 0e", appErr.Error())
+		assert.Equal(t, []string{
+			"errFunc0e1p",
+			"errFunc0e1p2p",
+			"errFunc0e1p2p3pg.func1",
+			"errFunc0e1p2p3pg4p",
+			"TestAll.func6",
+			"tRunner",
+		}, funcNamesFromStackTrace(appErr.StackTrace))
+	})
 }
 
 func wrapOrigin(err error) error {
@@ -469,6 +496,20 @@ func errFunc0e1p2p3fg() chan error {
 }
 func errFunc0e1p2p3fg4f() error {
 	return Wrap(<-errFunc0e1p2p3fg(), WithMessage("4f"), WithCode(500), WithIgnorable())
+}
+func errFunc0e1p2p3fg4f5p() error {
+	return pkgerrors.Wrap(errFunc0e1p2p3fg4f(), "5p")
+}
+
+func errFunc0e1p2p3pg() chan error {
+	c := make(chan error)
+	go func() {
+		c <- pkgerrors.Wrap(errFunc0e1p2p(), "3pg")
+	}()
+	return c
+}
+func errFunc0e1p2p3pg4p() error {
+	return pkgerrors.Wrap(<-errFunc0e1p2p3pg(), "4p")
 }
 
 func errFunc0e1p2p3f4p() error {

--- a/error_test.go
+++ b/error_test.go
@@ -364,44 +364,44 @@ func TestWrap(t *testing.T) {
 
 func TestAll(t *testing.T) {
 	{
-		appErr := Unwrap(errFunc3())
-		assert.Equal(t, "e2: e1: e0", appErr.Error())
+		appErr := Unwrap(errFunc0e1p2p3f())
+		assert.Equal(t, "2p: 1p: 0e", appErr.Error())
 		assert.Equal(t, nil, appErr.Code)
 		assert.Equal(t, false, appErr.Ignorable)
 		assert.Equal(t, []string{
-			"errFunc1",
-			"errFunc2",
-			"errFunc3",
+			"errFunc0e1p",
+			"errFunc0e1p2p",
+			"errFunc0e1p2p3f",
 			"TestAll",
 			"tRunner",
 		}, funcNamesFromStackTrace(appErr.StackTrace))
 	}
 
 	{
-		appErr := Unwrap(errFunc4())
-		assert.Equal(t, "e4: e2: e1: e0", appErr.Error())
+		appErr := Unwrap(errFunc0e1p2p3f4f())
+		assert.Equal(t, "4f: 2p: 1p: 0e", appErr.Error())
 		assert.Equal(t, 500, appErr.Code)
 		assert.Equal(t, true, appErr.Ignorable)
 		assert.Equal(t, []string{
-			"errFunc1",
-			"errFunc2",
-			"errFunc3",
-			"errFunc4",
+			"errFunc0e1p",
+			"errFunc0e1p2p",
+			"errFunc0e1p2p3f",
+			"errFunc0e1p2p3f4f",
 			"TestAll",
 			"tRunner",
 		}, funcNamesFromStackTrace(appErr.StackTrace))
 	}
 
 	{
-		appErr := Unwrap(errFunc4Goroutine())
-		assert.Equal(t, "e4: e2: e1: e0", appErr.Error())
+		appErr := Unwrap(errFunc0e1p2p3fg4f())
+		assert.Equal(t, "4f: 2p: 1p: 0e", appErr.Error())
 		assert.Equal(t, 500, appErr.Code)
 		assert.Equal(t, true, appErr.Ignorable)
 		assert.Equal(t, []string{
-			"errFunc1",
-			"errFunc2",
-			"errFunc3Goroutine.func1",
-			"errFunc4Goroutine",
+			"errFunc0e1p",
+			"errFunc0e1p2p",
+			"errFunc0e1p2p3fg.func1",
+			"errFunc0e1p2p3fg4f",
 			"TestAll",
 			"tRunner",
 		}, funcNamesFromStackTrace(appErr.StackTrace))
@@ -412,36 +412,48 @@ func wrapOrigin(err error) error {
 	return Wrap(err)
 }
 
-func errFunc0() error {
-	return errors.New("e0")
-}
-func errFunc1() error {
-	return pkgerrors.Wrap(errFunc0(), "e1")
-}
-func errFunc2() error {
-	return pkgerrors.Wrap(errFunc1(), "e2")
-}
-func errFunc3() error {
-	return Wrap(errFunc2())
-}
-func errFunc4() error {
-	return Wrap(errFunc3(), WithMessage("e4"), WithCode(500), WithIgnorable())
-}
-
-func errFunc3Goroutine() chan error {
-	c := make(chan error)
-	go func() {
-		c <- Wrap(errFunc2())
-	}()
-	return c
-}
-func errFunc4Goroutine() error {
-	return Wrap(<-errFunc3Goroutine(), WithMessage("e4"), WithCode(500), WithIgnorable())
-}
-
 func funcNamesFromStackTrace(stackTrace StackTrace) (funcNames []string) {
 	for _, frame := range stackTrace {
 		funcNames = append(funcNames, frame.Func)
 	}
 	return
+}
+
+// Error functions
+//
+// How to read: `errFunc0e1p2p3fg4f`
+//
+// Prefix   Error type: e = build-in errors, f = srvc/fail, p = pkg/errors
+// |        |
+// errFunc 0e 1p 2p 3fg 4f
+// ^^^^^^^ |          |
+//         Depth      Goroutine involved
+//
+// errors -> pkg/errors -> pkg/errors -> fail (goroutine) -> fail
+
+func errFunc0e() error {
+	return errors.New("0e")
+}
+func errFunc0e1p() error {
+	return pkgerrors.Wrap(errFunc0e(), "1p")
+}
+func errFunc0e1p2p() error {
+	return pkgerrors.Wrap(errFunc0e1p(), "2p")
+}
+func errFunc0e1p2p3f() error {
+	return Wrap(errFunc0e1p2p())
+}
+func errFunc0e1p2p3f4f() error {
+	return Wrap(errFunc0e1p2p3f(), WithMessage("4f"), WithCode(500), WithIgnorable())
+}
+
+func errFunc0e1p2p3fg() chan error {
+	c := make(chan error)
+	go func() {
+		c <- Wrap(errFunc0e1p2p())
+	}()
+	return c
+}
+func errFunc0e1p2p3fg4f() error {
+	return Wrap(<-errFunc0e1p2p3fg(), WithMessage("4f"), WithCode(500), WithIgnorable())
 }

--- a/pkgerrors.go
+++ b/pkgerrors.go
@@ -79,7 +79,7 @@ func extractPkgError(err error) *pkgError {
 		break
 	}
 
-	if len(stackTraces) == 0 {
+	if len(stackTraces) == 0 && rootErr == err {
 		return nil
 	}
 

--- a/pkgerrors.go
+++ b/pkgerrors.go
@@ -98,18 +98,22 @@ func extractPkgError(err error) *pkgError {
 	//                           '-.
 	//                              \
 	// "mesasge 2: message 1: e0" : "message 1: e0" --> ": message 1: e0" --> "messages 2"
+	var cleanedMessages []string
 	trailingMessage := rootErr.Error()
 	for i := len(messages) - 1; i >= 0; i-- {
 		if strings.HasSuffix(messages[i], pkgErrorsMessageDelimiter+trailingMessage) {
 			trimmed := strings.TrimSuffix(messages[i], pkgErrorsMessageDelimiter+trailingMessage)
 			trailingMessage = messages[i]
-			messages[i] = trimmed
+
+			if trimmed != "" { // Discard empty messages
+				cleanedMessages = append([]string{trimmed}, cleanedMessages...)
+			}
 		}
 	}
 
 	return &pkgError{
 		Err:        rootErr,
-		Messages:   messages,
+		Messages:   cleanedMessages,
 		StackTrace: reduceStackTraces(stackTraces),
 	}
 }

--- a/pkgerrors_test.go
+++ b/pkgerrors_test.go
@@ -85,6 +85,17 @@ func TestExtractPkgError(t *testing.T) {
 			assert.Equal(t, "pkgErrorsWrap", pkgErr.StackTrace[0].Func)
 		})
 	})
+
+	t.Run("pkg/errors.WithMessage", func(t *testing.T) {
+		err0 := errors.New("error")
+		err1 := pkgerrors.WithMessage(err0, "message")
+
+		pkgErr := extractPkgError(err1)
+		assert.NotNil(t, pkgErr)
+		assert.Equal(t, []string{"message"}, pkgErr.Messages)
+		assert.Equal(t, err0, pkgErr.Err)
+		assert.Empty(t, pkgErr.StackTrace)
+	})
 }
 
 func TestConvertPkgError(t *testing.T) {

--- a/pkgerrors_test.go
+++ b/pkgerrors_test.go
@@ -56,6 +56,34 @@ func TestExtractPkgError(t *testing.T) {
 			assert.NotEmpty(t, pkgErr.StackTrace)
 			assert.Equal(t, "pkgErrorsWrap", pkgErr.StackTrace[0].Func)
 		})
+
+		t.Run("multiple wrap with an empty message (first)", func(t *testing.T) {
+			err0 := errors.New("error")
+			err1 := pkgErrorsWrap(err0, "")
+			err2 := pkgErrorsWrap(err1, "message 2")
+			err3 := pkgErrorsWrap(err2, "message 3")
+
+			pkgErr := extractPkgError(err3)
+			assert.NotNil(t, pkgErr)
+			assert.Equal(t, []string{"message 3", "message 2"}, pkgErr.Messages)
+			assert.Equal(t, err0, pkgErr.Err)
+			assert.NotEmpty(t, pkgErr.StackTrace)
+			assert.Equal(t, "pkgErrorsWrap", pkgErr.StackTrace[0].Func)
+		})
+
+		t.Run("multiple wrap with an empty message (middle)", func(t *testing.T) {
+			err0 := errors.New("error")
+			err1 := pkgErrorsWrap(err0, "message 1")
+			err2 := pkgErrorsWrap(err1, "")
+			err3 := pkgErrorsWrap(err2, "message 3")
+
+			pkgErr := extractPkgError(err3)
+			assert.NotNil(t, pkgErr)
+			assert.Equal(t, []string{"message 3", "message 1"}, pkgErr.Messages)
+			assert.Equal(t, err0, pkgErr.Err)
+			assert.NotEmpty(t, pkgErr.StackTrace)
+			assert.Equal(t, "pkgErrorsWrap", pkgErr.StackTrace[0].Func)
+		})
 	})
 }
 

--- a/pkgerrors_test.go
+++ b/pkgerrors_test.go
@@ -15,22 +15,37 @@ func TestExtractPkgError(t *testing.T) {
 
 		pkgErr := extractPkgError(err)
 		assert.NotNil(t, pkgErr)
-		assert.Equal(t, "", pkgErr.Message)
+		assert.Equal(t, []string(nil), pkgErr.Messages)
 		assert.Equal(t, err, pkgErr.Err)
 		assert.NotEmpty(t, pkgErr.StackTrace)
 		assert.Equal(t, "pkgErrorsNew", pkgErr.StackTrace[0].Func)
 	})
 
 	t.Run("pkg/errors.Wrap", func(t *testing.T) {
-		err0 := errors.New("error")
-		err1 := pkgErrorsWrap(err0, "message")
+		t.Run("single wrap", func(t *testing.T) {
+			err0 := errors.New("error")
+			err1 := pkgErrorsWrap(err0, "message")
 
-		pkgErr := extractPkgError(err1)
-		assert.NotNil(t, pkgErr)
-		assert.Equal(t, "message", pkgErr.Message)
-		assert.Equal(t, err0, pkgErr.Err)
-		assert.NotEmpty(t, pkgErr.StackTrace)
-		assert.Equal(t, "pkgErrorsWrap", pkgErr.StackTrace[0].Func)
+			pkgErr := extractPkgError(err1)
+			assert.NotNil(t, pkgErr)
+			assert.Equal(t, []string{"message"}, pkgErr.Messages)
+			assert.Equal(t, err0, pkgErr.Err)
+			assert.NotEmpty(t, pkgErr.StackTrace)
+			assert.Equal(t, "pkgErrorsWrap", pkgErr.StackTrace[0].Func)
+		})
+
+		t.Run("multiple wrap", func(t *testing.T) {
+			err0 := errors.New("error")
+			err1 := pkgErrorsWrap(err0, "message 1")
+			err2 := pkgErrorsWrap(err1, "message 2")
+
+			pkgErr := extractPkgError(err2)
+			assert.NotNil(t, pkgErr)
+			assert.Equal(t, []string{"message 2", "message 1"}, pkgErr.Messages)
+			assert.Equal(t, err0, pkgErr.Err)
+			assert.NotEmpty(t, pkgErr.StackTrace)
+			assert.Equal(t, "pkgErrorsWrap", pkgErr.StackTrace[0].Func)
+		})
 	})
 }
 

--- a/pkgerrors_test.go
+++ b/pkgerrors_test.go
@@ -10,6 +10,16 @@ import (
 )
 
 func TestExtractPkgError(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		pkgErr := extractPkgError(nil)
+		assert.Nil(t, pkgErr)
+	})
+
+	t.Run("not a pkg/errors", func(t *testing.T) {
+		pkgErr := extractPkgError(errors.New("error"))
+		assert.Nil(t, pkgErr)
+	})
+
 	t.Run("pkg/errors.New", func(t *testing.T) {
 		err := pkgErrorsNew("message")
 


### PR DESCRIPTION
## What

- Convert `pkg/errors` in `Unwrap`.
- Factorize `Wrap` and `wrap` with `Unwrap`.
- Improve handling of `pkg/errors`.
