### PR TITLE
Add /v4 suffix for go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ import (
 	"errors"
 
 	"github.com/k0kubun/pp"
-	"github.com/srvc/fail"
+	"github.com/srvc/fail/v4"
 )
 
 var myErr = fail.New("this is the root cause")
@@ -285,7 +285,7 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/srvc/fail"
+	"github.com/srvc/fail/v4"
 	"github.com/creasty/gin-contrib/readbody"
 	"github.com/gin-gonic/gin"
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/srvc/fail
+module github.com/srvc/fail/v4
 
 go 1.13
 


### PR DESCRIPTION
Version 4.1.0 includes support #24 for Go Modules, but this is broken; we need `/v4` suffix.